### PR TITLE
Made View.touch more precise

### DIFF
--- a/AndroidViewClient/src/com/dtmilano/android/viewclient.py
+++ b/AndroidViewClient/src/com/dtmilano/android/viewclient.py
@@ -150,7 +150,7 @@ class View:
         '''
         (x, y) = self.getXY()
         w = int(self.map['layout:getWidth()'])
-        h = int(self.map['layout:getHeight()'] + self.barHeight)
+        h = int(self.map['layout:getHeight()'])
         return ((x, y), (x+w, y+h))
 
     def getCenter(self):
@@ -167,7 +167,6 @@ class View:
         Touches this View
         '''
         (x, y) = self.getCenter()
-        print 'touching (%d, %d)' % (x, y)
         if DEBUG:
             print >>sys.stderr, "should touch @ (%d, %d)" % (x, y)
         self.device.touch(x, y, type)


### PR DESCRIPTION
Hi there,

This a great tool that you've made!

I just ran into an issue where View.push() was missing small TextView links.

It turns out that the notification bar is not included in the View's coordinates, but needs to be considered when doing a device.touch() call (on my device at least). (0, 0) would be just under the notification bar as far as the View is concerned, but is at the top of the notification bar for device.touch().

I added an offset based on the screen density of the device, using the values I found here:
http://stackoverflow.com/questions/3600713/size-of-android-notification-bar-and-title-bar

Use or discard as you see fit.

Cheers,
Dean
