### PR TITLE
It is now possible to read GingerBreads' mText

### DIFF
--- a/AndroidViewClient/src/com/dtmilano/android/viewclient.py
+++ b/AndroidViewClient/src/com/dtmilano/android/viewclient.py
@@ -720,7 +720,11 @@ class ViewClient:
                     self.build[prop] = int(self.build[prop])
             except:
                 self.build[prop] = -1
-                
+
+        if int(self.build["version.sdk"]) <= 10: # gingerbread 2.3.3
+            global TEXT_PROPERTY
+            TEXT_PROPERTY = "mText"
+
         if autodump:
             self.dump()
     


### PR DESCRIPTION
Hi. This is a small patch to start some compatibility with GingerBread. It changes TEXT_PROPERTY from "text:mText" to mText on such devices. 

More patches shall come soon.
