### PR TITLE
Update window regex for latest dumpsys format

### DIFF
--- a/AndroidViewClient/src/com/dtmilano/android/viewclient.py
+++ b/AndroidViewClient/src/com/dtmilano/android/viewclient.py
@@ -1076,7 +1076,7 @@ class ViewClient:
         if secure == '1' and debuggable == '0' and not ignoresecuredevice and version < 16:
             print >> sys.stderr, "%s: ERROR: Device is secure, AndroidViewClient won't work." % progname
             sys.exit(2)
-        if re.search("[.*()+]", serialno):
+        if re.search("[.*()+]", serialno) and not re.search("(\d{1,3}\.){3}\d{1,3}"):
             # if a regex was used we have to determine the serialno used
             serialno = ViewClient.__obtainDeviceSerialNumber(device)
         return device, serialno


### PR DESCRIPTION
dumpsys is including a new string (userid?) in the Window output. We
ignore it when it exists. This fixes an issue where the status bar is
not being identified and factored into coordinate computations.

Signed-off-by: Matt Gumbel matthew.k.gumbel@linux.intel.com
