### PR TITLE
Make View.getXY() work w/ UIAutomator

### DIFF
--- a/AndroidViewClient/src/com/dtmilano/android/viewclient.py
+++ b/AndroidViewClient/src/com/dtmilano/android/viewclient.py
@@ -452,22 +452,24 @@ class View:
         hx = 0
         hy = 0
         
-        if not self.useUiAutomator:
-            if DEBUG_COORDS: print >> sys.stderr, "   getXY: not using UiAutomator, calculating parent coordinates"
-            while parent != None:
-                if DEBUG_COORDS: print >> sys.stderr, "      getXY: parent: %s %s <<<<" % (parent.getClass(), parent.getId())
-                if SKIP_CERTAIN_CLASSES_IN_GET_XY_ENABLED:
-                    if parent.getClass() in [ 'com.android.internal.widget.ActionBarView',
-                                       'com.android.internal.widget.ActionBarContextView',
-                                       'com.android.internal.view.menu.ActionMenuView',
-                                       'com.android.internal.policy.impl.PhoneWindow$DecorView' ]:
-                        if DEBUG_COORDS: print >> sys.stderr, "   getXY: skipping %s %s (%d,%d)" % (parent.getClass(), parent.getId(), parent.getX(), parent.getY())
-                        parent = parent.parent
-                        continue
-                if DEBUG_COORDS: print >> sys.stderr, "   getXY: parent=%s x=%d hx=%d y=%d hy=%d" % (parent.getId(), x, hx, y, hy)
-                hx += parent.getX()
-                hy += parent.getY()
-                parent = parent.parent
+        if self.useUiAutomator:
+            return (x, y)
+
+        if DEBUG_COORDS: print >> sys.stderr, "   getXY: not using UiAutomator, calculating parent coordinates"
+        while parent != None:
+            if DEBUG_COORDS: print >> sys.stderr, "      getXY: parent: %s %s <<<<" % (parent.getClass(), parent.getId())
+            if SKIP_CERTAIN_CLASSES_IN_GET_XY_ENABLED:
+                if parent.getClass() in [ 'com.android.internal.widget.ActionBarView',
+                                   'com.android.internal.widget.ActionBarContextView',
+                                   'com.android.internal.view.menu.ActionMenuView',
+                                   'com.android.internal.policy.impl.PhoneWindow$DecorView' ]:
+                    if DEBUG_COORDS: print >> sys.stderr, "   getXY: skipping %s %s (%d,%d)" % (parent.getClass(), parent.getId(), parent.getX(), parent.getY())
+                    parent = parent.parent
+                    continue
+            if DEBUG_COORDS: print >> sys.stderr, "   getXY: parent=%s x=%d hx=%d y=%d hy=%d" % (parent.getId(), x, hx, y, hy)
+            hx += parent.getX()
+            hy += parent.getY()
+            parent = parent.parent
 
         (wvx, wvy) = self.__dumpWindowsInformation()
         if DEBUG_COORDS:


### PR DESCRIPTION
UIAutomator xml file returns bounds of view in global (screen) coords,
not relative to parent window(s), view(s), or statusbar. View.getXY() is
adapted to not do coordinate translation when UIAutomator is being used.

Signed-off-by: Matt Gumbel matthew.k.gumbel@linux.intel.com
