### PR TITLE
Added a backspace function to EditText

### DIFF
--- a/AndroidViewClient/src/com/dtmilano/android/viewclient.py
+++ b/AndroidViewClient/src/com/dtmilano/android/viewclient.py
@@ -753,6 +753,11 @@ class EditText(TextView):
         self.device.type(text)
         MonkeyRunner.sleep(1)
 
+    def backspace(self):
+        self.touch()
+        MonkeyRunner.sleep(1)
+        self.device.press('KEYCODE_DEL', MonkeyDevice.DOWN_AND_UP)
+
 class UiAutomator2AndroidViewClient():
     '''
     UiAutomator XML to AndroidViewClient


### PR DESCRIPTION
It is just a tiny missing feature. You could type in an EditText, but couldn't delete from it. Now you can.
