### PR TITLE
viewclient: added switch for --compressed option

### DIFF
--- a/src/com/dtmilano/android/viewclient.py
+++ b/src/com/dtmilano/android/viewclient.py
@@ -1348,7 +1348,7 @@ class ViewClient:
     imageDirectory = None
     ''' The directory used to store screenshot images '''
 
-    def __init__(self, device, serialno, adb=None, autodump=True, forceviewserveruse=False, localport=VIEW_SERVER_PORT, remoteport=VIEW_SERVER_PORT, startviewserver=True, ignoreuiautomatorkilled=False):
+    def __init__(self, device, serialno, adb=None, autodump=True, forceviewserveruse=False, localport=VIEW_SERVER_PORT, remoteport=VIEW_SERVER_PORT, startviewserver=True, ignoreuiautomatorkilled=False, compresseddump=True):
         '''
         Constructor
 
@@ -1372,6 +1372,8 @@ class ViewClient:
         @param startviewserver: Whether to start the B{global} ViewServer
         @type ignoreuiautomatorkilled: boolean
         @param ignoreuiautomatorkilled: Ignores received B{Killed} message from C{uiautomator}
+        @type compresseddump: boolean
+        @param compresseddump: turns --compressed flag for uiautomator dump on/off
         '''
 
         if not device:
@@ -1492,7 +1494,12 @@ class ViewClient:
 
         self.uiDevice = UiDevice(self)
         ''' The L{UiDevice} '''
-        
+
+        ''' The output of compressed dump is different than output of uncompressed one.
+        If one requires uncompressed output, this option should be set to False
+        '''
+        self.compressedDump = compresseddump
+
         if autodump:
             self.dump()
 
@@ -2103,7 +2110,7 @@ class ViewClient:
         if self.useUiAutomator:
             # NOTICE:
             # Using /dev/tty this works even on devices with no sdcard
-            received = unicode(self.device.shell('uiautomator dump %s /dev/tty >/dev/null' % ('--compressed' if self.getSdkVersion() >= 18 else '')), encoding='utf-8', errors='replace')
+            received = unicode(self.device.shell('uiautomator dump %s /dev/tty >/dev/null' % ('--compressed' if self.getSdkVersion() >= 18 and self.compressedDump else '')), encoding='utf-8', errors='replace')
             if not received:
                 raise RuntimeError('ERROR: Empty UiAutomator dump was received')
             if DEBUG:


### PR DESCRIPTION
The --compressed option is used for uiautomator dump by default. There
was no option to switch it of. As output of 'compressed' and
'uncompressed' dump is different, backward compatibility was broken.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>