### PR TITLE
platform.system() could return a value of Java causing the adb look up to fail on a windows system.

### DIFF
--- a/src/com/dtmilano/android/common.py
+++ b/src/com/dtmilano/android/common.py
@@ -68,13 +68,13 @@ def obtainAdbPath():
 
     osName = platform.system()
     isWindows = False
+    adb = 'adb'
+    
     if (osName.startswith('Windows')) or (osName.startswith('Java')):
         envOSName = os.getenv('os') #this should work as it has been set since xp.
         if envOSName.startswith('Windows'):
         	adb = 'adb.exe'
         	isWindows = True
-    else:
-        adb = 'adb'
 
     ANDROID_HOME = os.environ['ANDROID_HOME'] if os.environ.has_key('ANDROID_HOME') else '/opt/android-sdk'
     HOME = os.environ['HOME'] if os.environ.has_key('HOME') else ''

--- a/src/com/dtmilano/android/common.py
+++ b/src/com/dtmilano/android/common.py
@@ -68,9 +68,11 @@ def obtainAdbPath():
 
     osName = platform.system()
     isWindows = False
-    if osName.startswith('Windows'):
-        adb = 'adb.exe'
-        isWindows = True
+    if (osName.startswith('Windows')) or (osName.startswith('Java')):
+        envOSName = os.getenv('os') #this should work as it has been set since xp.
+        if envOSName.startswith('Windows'):
+        	adb = 'adb.exe'
+        	isWindows = True
     else:
         adb = 'adb'
 


### PR DESCRIPTION
Needed to do and extra check if platform.system() returns the value of 'Java' and check and the OS environment variable to see if we are in a Windows environment.  The os.getenv() will default to none if it not set.