### PR TITLE
Re-Expose method to allow clients to grab screensize

### DIFF
--- a/src/com/dtmilano/android/adb/adbclient.py
+++ b/src/com/dtmilano/android/adb/adbclient.py
@@ -394,7 +394,7 @@ class AdbClient:
             sout = adbClient.socket.makefile("r")
             return sout
 
-    def __getRestrictedScreen(self):
+    def getRestrictedScreen(self):
         ''' Gets C{mRestrictedScreen} values from dumpsys. This is a method to obtain display dimensions '''
 
         rsRE = re.compile('\s*mRestrictedScreen=\((?P<x>\d+),(?P<y>\d+)\) (?P<w>\d+)x(?P<h>\d+)')


### PR DESCRIPTION
I was using this method as follows:

```python
     _,_,width, height = vc.device.getRestrictedScreen()
    w_midpoint = int(int(width)/2)
    h_midpoint = int(int(height)/2)
    vc.device.drag((w_midpoint,h_midpoint),(w_midpoint - 200, h_midpoint), 100)
```

I would like to make this function public again, so that I can continue to use it.  It is not used internally anywhere and is dead code otherwise.