### PR TITLE
Update adbclient.py

### DIFF
--- a/src/com/dtmilano/android/adb/adbclient.py
+++ b/src/com/dtmilano/android/adb/adbclient.py
@@ -771,7 +771,7 @@ class AdbClient:
         version = self.getSdkVersion()
         if version <= 15:
             raise RuntimeError('drag: API <= 15 not supported (version=%d)' % version)
-        elif version <= 17:
+        elif version <= 18:
             self.shell('input swipe %d %d %d %d' % (x0, y0, x1, y1))
         else:
             self.shell('input touchscreen swipe %d %d %d %d %d' % (x0, y0, x1, y1, duration))


### PR DESCRIPTION
Sdk level problem while using drag(x1,x2,y1,y2,duration): The place should be 18. Sdk version 18 don't support arg 'duration', I tested 5 devices. Only api level >=19 support the arg 'duration'.