### PR TITLE
A mistake I made!

### DIFF
--- a/src/com/dtmilano/android/adb/adbclient.py
+++ b/src/com/dtmilano/android/adb/adbclient.py
@@ -771,7 +771,7 @@ class AdbClient:
         version = self.getSdkVersion()
         if version <= 15:
             raise RuntimeError('drag: API <= 15 not supported (version=%d)' % version)
-        elif version <= 18:
+        elif version <= 17:
             self.shell('input swipe %d %d %d %d' % (x0, y0, x1, y1))
         else:
             self.shell('input touchscreen swipe %d %d %d %d %d' % (x0, y0, x1, y1, duration))


### PR DESCRIPTION
Very sorry that I made a mistake!
The sdk version is actual 17(I mistake as 18).
API levle >= 18 (4.3) supports the param 'duration'.
Very sorry!