### PR TITLE
AVC: Fix adbclient.type to check type and fix package tests

### DIFF
--- a/src/com/dtmilano/android/adb/adbclient.py
+++ b/src/com/dtmilano/android/adb/adbclient.py
@@ -798,8 +798,11 @@ class AdbClient:
 
     def type(self, text):
         self.__checkTransport()
-        escaped = text.replace('%s', '\\%s')
-        encoded = escaped.replace(' ', '%s')
+        if type(text) is str:
+            escaped = text.replace('%s', '\\%s')
+            encoded = escaped.replace(' ', '%s')
+        else:
+            encoded = str(text);
         #FIXME find out which characters can be dangerous,
         # for exmaple not worst idea to escape " 
         self.shell(u'input text "%s"' % encoded)


### PR DESCRIPTION
All adbclienttests should now run on most devices (any one with a calculator)