### PR TITLE
Fix absolute adb path in Mac and Linux

### DIFF
--- a/src/com/dtmilano/android/common.py
+++ b/src/com/dtmilano/android/common.py
@@ -97,13 +97,13 @@ def obtainAdbPath():
         possibleChoices.append(os.path.join("""C:\Program Files\Android\android-sdk\platform-tools""", adb))
         possibleChoices.append(os.path.join("""C:\Program Files (x86)\Android\android-sdk\platform-tools""", adb))
     elif osName.startswith('Linux'):
-        possibleChoices.append(os.path.join("opt", "android-sdk-linux", 'platform-tools', adb))
+        possibleChoices.append(os.path.join(os.sep, "opt", "android-sdk-linux", 'platform-tools', adb))
         possibleChoices.append(os.path.join(HOME, "opt", "android-sdk-linux", 'platform-tools', adb))
         possibleChoices.append(os.path.join(HOME, "android-sdk-linux", 'platform-tools', adb))
         possibleChoices.append(os.path.join(HOME, 'Android', 'Sdk', 'platform-tools', adb))
     elif osName.startswith('Mac'):
         possibleChoices.append(os.path.join(HOME, "Library", "Android", "sdk", 'platform-tools', adb))
-        possibleChoices.append(os.path.join("opt", "android-sdk-mac_x86", 'platform-tools', adb))
+        possibleChoices.append(os.path.join(os.sep, "opt", "android-sdk-mac_x86", 'platform-tools', adb))
         possibleChoices.append(os.path.join(HOME, "opt", "android-sdk-mac", 'platform-tools', adb))
         possibleChoices.append(os.path.join(HOME, "android-sdk-mac", 'platform-tools', adb))
         possibleChoices.append(os.path.join(HOME, "opt", "android-sdk-mac_x86", 'platform-tools', adb))


### PR DESCRIPTION
Code was intended to search an absolute path (/opt/blah) but the first separation character isn't automatically added by os.join