### PR TITLE
Fixed domain name recognition

### DIFF
--- a/src/com/dtmilano/android/viewclient.py
+++ b/src/com/dtmilano/android/viewclient.py
@@ -130,7 +130,11 @@ GONE = 0x8
 RegexType = type(re.compile(''))
 IP_RE = re.compile('^(\d{1,3}\.){3}\d{1,3}$')
 ID_RE = re.compile('id/([^/]*)(/(\d+))?')
-
+IP_DOMAIN_NAME_PORT_REGEX = r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|' \
+                            r'localhost|' \
+                            r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})' \
+                            r'(?::\d+)?' \
+                            r'(?:/?|[/?]\S+)$'
 
 class ViewNotFoundException(Exception):
     '''
@@ -2590,7 +2594,8 @@ class ViewClient:
             if DEBUG_DEVICE: print >>sys.stderr, "ViewClient: adding default port to serialno", serialno, ADB_DEFAULT_PORT
             return serialno + ':%d' % ADB_DEFAULT_PORT
 
-        ipPortRE = re.compile('^\d+\.\d+.\d+.\d+:\d+$')
+        ipPortRE = re.compile(IP_DOMAIN_NAME_PORT_REGEX, re.IGNORECASE)
+
         if ipPortRE.match(serialno):
             # nothing to map
             return serialno
@@ -2714,7 +2719,10 @@ class ViewClient:
         if device.serialno:
             # If we know the serialno because it was set by AdbClient, use it
             serialno = device.serialno
-        if re.search("[.*()+]", serialno) and not re.search("(\d{1,3}\.){3}\d{1,3}", serialno):
+
+        ipPortRE = re.compile(IP_DOMAIN_NAME_PORT_REGEX, re.IGNORECASE)
+
+        if re.search("[.*()+]", serialno) and not ipPortRE.match(serialno):
             # if a regex was used we have to determine the serialno used
             serialno = ViewClient.__obtainDeviceSerialNumber(device)
         if verbose:


### PR DESCRIPTION
Hi,

My problem was when I needed to use culebra on a remote device mapped by a domain name.

Example:

$ adb devices
List of devices attached
devices.alexandre.com:7777  device


I was getting this error below, but domain name is not a regular expression.

Traceback (most recent call last):
  File "single_country_wizard_multi_vertical.py", line 33, in <module>
    vc = ViewClient(device, device_id, **kwargs2)
  File "/home/alexandre/IdeaProjects/AndroidViewClient/src/com/dtmilano/android/viewclient.py", line 2421, in __init__
    self.serialno = self.__mapSerialNo(serialno)
  File "/home/alexandre/IdeaProjects/AndroidViewClient/src/com/dtmilano/android/viewclient.py", line 2609, in __mapSerialNo
    raise ValueError("Regular expression not supported as serialno in ViewClient. Found '%s'" % serialno)
ValueError: Regular expression not supported as serialno in ViewClient. Found 'devices.alexandre.com:7777'
