### PR TITLE
Use the existing AdbClient to force-stop culebratester

### DIFF
--- a/src/com/dtmilano/android/viewclient.py
+++ b/src/com/dtmilano/android/viewclient.py
@@ -2561,7 +2561,7 @@ class ViewClient:
             else:
                 # culebratester Intrumentation running prevents `uiautomator dump` from working correctly, then if we are not
                 # using UiAutomatorHelper let's kill it, just in case
-                subprocess.check_call([self.adb, '-s', self.serialno, 'shell', 'am', 'force-stop', 'com.dtmilano.android.culebratester'])
+                self.device.shell('am force-stop com.dtmilano.android.culebratester')
 
 
         self.uiDevice = UiDevice(self)


### PR DESCRIPTION
I was having the same problem as https://github.com/dtmilano/AndroidViewClient/issues/208 and decided to track it down.

I'm running `adb` inside a Docker container on a Raspberry Pi. With the help of some of the debugging steps in the linked issue (`netstat`), I realized that adb wasn't binding to 5037.

I ended up starting adb with `adb -a -P 5037 nodaemon server` to bind to all interfaces (it seems like there is a bug where `-a` doesn't make it to the daemon). My AndroidViewClient script kept getting caught on the line changed in this PR. I believe it's because going though `AdbClient.shell` allows you to specifiy the `ANDROID_ADB_SERVER_HOST` (`0.0.0.0`) and port, whereas the changed line simply calls adb without any of AdbClient's properties.

So, this PR allows me to use AVC inside Docker on a Raspberry Pi.

If there is a testing or contribution guide you'd like me to use, feel free to point me to it and I'll run/write some tests.

And while I'm here, thanks for this software, @dtmilano!