### PR TITLE
Fix for adb shell lock issue #252

### DIFF
--- a/src/com/dtmilano/android/adb/adbclient.py
+++ b/src/com/dtmilano/android/adb/adbclient.py
@@ -486,7 +486,6 @@ class AdbClient:
         #
         # synchronized
         #
-        self.lock.acquire()
         with self.lock:
             if _cmd:
                 self.__send('shell:%s' % _cmd, checkok=True, reconnect=False)


### PR DESCRIPTION
When running CulebraTestCase tests, this line in the AdbClient#shell() seems to cause deadlocks between main thread and RunTestsThread thread, as it should have either with self.lock or separate self.lock.acquire() and self.lock.release() statements, but not both.

Please, see #252 for details.