### PR TITLE
add support for activities within inner classes

### DIFF
--- a/src/com/dtmilano/android/adb/adbclient.py
+++ b/src/com/dtmilano/android/adb/adbclient.py
@@ -1288,7 +1288,7 @@ class AdbClient:
     def getTopActivityNameAndPid(self):
         dat = self.shell('dumpsys activity top')
         lines = dat.splitlines()
-        activityRE = re.compile('\s*ACTIVITY ([A-Za-z0-9_.]+)/([A-Za-z0-9_.]+) \w+ pid=(\d+)')
+        activityRE = re.compile('\s*ACTIVITY ([A-Za-z0-9_.]+)/([A-Za-z0-9_.\$]+) \w+ pid=(\d+)')
         m = activityRE.search(lines[1])
         if m:
             return m.group(1), m.group(2), m.group(3)


### PR DESCRIPTION
AVC fails to detect activities created within inner classes, i.e `com.company.package/.Application$Activity`