### PR TITLE
match device by qualifiers too like adb does

### DIFF
--- a/src/com/dtmilano/android/adb/adbclient.py
+++ b/src/com/dtmilano/android/adb/adbclient.py
@@ -103,7 +103,10 @@ class Device:
     def __init__(self, serialno, status, qualifiers=None):
         self.serialno = serialno
         self.status = status
-        self.qualifiers = qualifiers
+        self.qualifiers = qualifiers.split(None) if qualifiers else None
+
+    def has_qualifier(self, qualifier):
+        return self.qualifiers and qualifier in self.qualifiers
 
     def __str__(self):
         return "<<<" + self.serialno + ", " + self.status + ", %s>>>" % self.qualifiers
@@ -434,7 +437,7 @@ class AdbClient:
         if len(devices) == 0:
             raise RuntimeError("ERROR: There are no connected devices")
         for device in devices:
-            if serialnoRE.match(device.serialno):
+            if serialnoRE.match(device.serialno) or device.has_qualifier(self.serialno):
                 found = True
                 break
         if not found:


### PR DESCRIPTION
For instance matching by devpath (like usb:1.1) is very useful for
devices that have identical serial numbers.

Adb accepts
adb -s <serialno>
adb -s <devpath>
adb -s <model:name>
adb -s <device:name>
adb -t <transport_id>

Let's support first four forms the same way.
The fifth seems to work as well with serial in form 'transport_id:1'

References
append_transport, acquire_one_transport, atransport::MatchesTarget
https://android.googlesource.com/platform/system/core/+/master/adb/transport.cpp