### PR TITLE
Keep adbclient.serialno intact if it's a valid transport name.

### DIFF
--- a/src/com/dtmilano/android/adb/adbclient.py
+++ b/src/com/dtmilano/android/adb/adbclient.py
@@ -416,7 +416,9 @@ class AdbClient:
                             device = Device.factory(line[4:])
                             if device.status == 'device':
                                 devices.append(device)
+                                # this looks like a bug, we skip serialno matching here
                                 found = True
+                                self.serialno = device.serialno
                                 break
                         if found:
                             break
@@ -437,12 +439,22 @@ class AdbClient:
         if len(devices) == 0:
             raise RuntimeError("ERROR: There are no connected devices")
         for device in devices:
-            if serialnoRE.match(device.serialno) or device.has_qualifier(self.serialno):
+            if serialnoRE.match(device.serialno):
+                found = True
+                # self.serialno could've been a regexp, we can't feed that to adb as a transport
+                self.serialno = device.serialno
+                break
+            if device.has_qualifier(self.serialno):
+                # self.serialno is a proper transport value, it could be more specific than device.serialno
+                # For instance devpath/usbpath specifies exactly one device, while serialno might be the same
+                # for reflashed devices.
+                # The only flipside here is that we fail to pick one (first/random) device from possibly many
+                # having the same qualifier (product: model: or device:) if they have different serials.
+                # This could be fixed by some custom logic or using host:transport-id: support in newer and.
                 found = True
                 break
         if not found:
             raise RuntimeError("ERROR: couldn't find device that matches '%s' in %s" % (self.serialno, devices))
-        self.serialno = device.serialno
         msg = 'host:transport:%s' % self.serialno
         if DEBUG:
             print >> sys.stderr, "    __setTransport: msg=", msg


### PR DESCRIPTION
Normally we match the device using serialno regexp, fetch the real
serialno and set it as a host:transport:

In case we match the device using qualifiers we can either fetch
the serialno or keep qualifier as host:transport: value, let's
switch to using qualifier to have means (devpath/usbpath qualifier)
to address devices having coinciding serialno (reflashed devices).

Without this fix we matched by devpath, picked up serialno and
got error from adb upon trying to set transport by serialno
(multiple devices error).