### PR TITLE
Android10 compatibility - isScreenOn

### DIFF
--- a/src/com/dtmilano/android/adb/adbclient.py
+++ b/src/com/dtmilano/android/adb/adbclient.py
@@ -1045,17 +1045,18 @@ class AdbClient:
 
         self.__checkTransport()
         window_policy = self.shell('dumpsys window policy')
-        
-        screenOnRE = re.compile('mScreenOnFully=(true|false)')  # Removed in Android 10 API 29
+              
+        # Deprecated in API 20, removed in API 29
+        screenOnRE = re.compile('mScreenOnFully=(true|false)')
         m = screenOnRE.search(window_policy)
         if m:
             return m.group(1) == 'true'
 
-        # Re-introduced in Android 9 API 28 (previously was '0' for off '2' for on)
-        screenStateRE = re.compile('screenState=(SCREEN_STATE_OFF|SCREEN_STATE_ON)')
+        # Added in API 20
+        screenStateRE = re.compile('interactiveState=(INTERACTIVE_STATE_AWAKE|INTERACTIVE_STATE_SLEEP)')
         m = screenStateRE.search(window_policy)
         if m:
-            return m.group(1) == 'SCREEN_STATE_ON'
+            return m.group(1) == 'INTERACTIVE_STATE_AWAKE'
 
         raise RuntimeError("Couldn't determine screen ON state")
 

--- a/src/com/dtmilano/android/adb/adbclient.py
+++ b/src/com/dtmilano/android/adb/adbclient.py
@@ -1044,10 +1044,19 @@ class AdbClient:
         """
 
         self.__checkTransport()
-        screenOnRE = re.compile('mScreenOnFully=(true|false)')
-        m = screenOnRE.search(self.shell('dumpsys window policy'))
+        window_policy = self.shell('dumpsys window policy')
+        
+        screenOnRE = re.compile('mScreenOnFully=(true|false)')  # Removed in Android 10 API 29
+        m = screenOnRE.search(window_policy)
         if m:
             return m.group(1) == 'true'
+
+        # Re-introduced in Android 9 API 28 (previously was '0' for off '2' for on)
+        screenStateRE = re.compile('screenState=(SCREEN_STATE_OFF|SCREEN_STATE_ON)')
+        m = screenStateRE.search(window_policy)
+        if m:
+            return m.group(1) == 'SCREEN_STATE_ON'
+
         raise RuntimeError("Couldn't determine screen ON state")
 
     def unlock(self):


### PR DESCRIPTION
In adbclient.py, isScreenOn() checks for mScreenFullyOn, which was removed in API 29. Following [documentation for PowerManager](https://developer.android.com/reference/android/os/PowerManager#isScreenOn()), I added a check for interactiveState prior to the RuntimeError to enable execution on Android 10 devices. 

Another option I explored was [using screenState](https://github.com/dtmilano/AndroidViewClient/commit/32de7dad270faef4523313adda829bd81f40fe49), but the documentation seems to indicate that interactiveState should be used.