### PR TITLE
Window resize fix (for orientation changes)

### DIFF
--- a/src/com/dtmilano/android/culebron.py
+++ b/src/com/dtmilano/android/culebron.py
@@ -1086,9 +1086,6 @@ This is usually installed by python package. Check your distribution details.
                 changed = True
                 break
         if changed:
-            self.window.geometry('%dx%d' % (self.device.display['width'] * self.scale,
-                                            self.device.display['height'] * self.scale + int(
-                                                self.statusBar.winfo_height())))
             self.deleteVignette()
             self.canvas.destroy()
             self.canvas = None


### PR DESCRIPTION
Manually setting the TK window geometry when the orientation changes was causing display issues, resulting in failure to extend the window horizontally and the window taking up extra space. 

This fix removes manual geometry setting and allows the window manager to compute the correct window size based off the size of the menu bar and canvas, which in turn bases its size off of the scaled screenshot. 