### PR TITLE
Add a convenience function to uninstall a package via ViewClient.

### DIFF
--- a/src/com/dtmilano/android/viewclient.py
+++ b/src/com/dtmilano/android/viewclient.py
@@ -4362,6 +4362,9 @@ On OSX install
         else:
             return subprocess.check_call([self.adb, "-s", self.serialno, "install", "-r", apk], shell=False)
 
+    def uninstallPackage(self, package):
+        return subprocess.check_call([self.adb, "-s", self.serialno, "uninstall", package], shell=False)
+
     @staticmethod
     def writeViewImageToFileInDir(view):
         '''


### PR DESCRIPTION
This PR adds a `ViewClient.uninstallPackage` function. As there is already a `ViewClient.installPackage` function, the symmetric would save the user the burden of remembering the syntax and to pass the expected serial argument of `adb`.