### PR TITLE
Add an option to grant all permissions when installing an APK.

### DIFF
--- a/src/com/dtmilano/android/viewclient.py
+++ b/src/com/dtmilano/android/viewclient.py
@@ -4356,11 +4356,17 @@ On OSX install
    $ brew install homebrew/python/pillow
 ''')
 
-    def installPackage(self, apk, allowTestApk=False):
+    def installPackage(self, apk, allowTestApk=False, grantAllPermissions=False):
+        command = [self.adb, "-s", self.serialno, "install", "-r"]
+
         if allowTestApk:
-            return subprocess.check_call([self.adb, "-s", self.serialno, "install", "-r", "-t", apk], shell=False)
-        else:
-            return subprocess.check_call([self.adb, "-s", self.serialno, "install", "-r", apk], shell=False)
+            command.append("-t")
+
+        if grantAllPermissions:
+            command.append("-g")
+
+        command.append(apk)
+        subprocess.check_call(command, shell=False)
 
     @staticmethod
     def writeViewImageToFileInDir(view):


### PR DESCRIPTION
`adb install` accepts a `-g` option to grant all permissions to the installed application. This greatly help testing as it allows to skip the permission request dialogs to have a "normal" workflow of the app. This PR adds an option to `ViewClient.installPackage` to enable this feature.