### PR TITLE
refactor: use `search` instead of `match` to look for attr that match

### DIFF
--- a/src/com/dtmilano/android/viewclient.py
+++ b/src/com/dtmilano/android/viewclient.py
@@ -3955,7 +3955,7 @@ class ViewClient:
         if DEBUG: print("__findViewWithAttributeInTreeThatMatches: checking if root=%s attr=%s matches %s" % (
             root.__smallStr__(), attr, regex), file=sys.stderr)
 
-        if root and attr in root.map and regex.match(root.map[attr]):
+        if root and attr in root.map and regex.search(root.map[attr]):
             if DEBUG: print("__findViewWithAttributeInTreeThatMatches:  FOUND: %s" % root.__smallStr__(),
                             file=sys.stderr)
             return root
@@ -3981,7 +3981,7 @@ class ViewClient:
             print("__findViewsWithAttributeInTreeThatMatches: checking if root=%s attr=%s matches %s" % (
                 root.__smallStr__(), attr, regex), file=sys.stderr)
 
-        if root and attr in root.map and regex.match(root.map[attr]):
+        if root and attr in root.map and regex.search(root.map[attr]):
             if DEBUG:
                 print("__findViewsWithAttributeInTreeThatMatches:  FOUND: %s" % root.__smallStr__(), file=sys.stderr)
             matchingViews.append(root)


### PR DESCRIPTION
`match` method try to match only from the start of the string
`search` method try to match from anywhere on the string

in my specific use case, word boundary (`\b`) doesn't work with `match` if the sub-string I looking for is in the middle of the string
```
>>> import re
>>> r = re.compile(rf"\babc\b")
>>> r.match("xxx abc yyy")  # doesn't work
>>> r.search("xxx abc yyy")  # work
<re.Match object; span=(4, 7), match='abc'>
```

[a workaround can be found here](https://github.com/dtmilano/AndroidViewClient/issues/330) (`r = re.compile(fr"^.*\babc\b.*$")`) but word boundary alone should work too

#
fixes #330 